### PR TITLE
URLだけで設定可能なようにURL中のパスワードをAPIキーとして扱う

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,7 @@ from kombu import transport, Connection, Queue
 
 transport.TRANSPORT_ALIASES["sakura-simplemq"] = "kombu_sakura_simplemq.transport:Transport"
 
-transport_options = {
-    "api_key": "YOUR_SIMPLEMQ_API_KEY",
-    "zone": "tk1b",
-}
-
-with Connection("sakura-simplemq://", transport_options=transport_options) as conn:
+with Connection("sakura-simplemq://:{}@".format("YOUR_SIMPLEMQ_API_KEY")) as conn:
     queue_name = "somequeue"
     queue = Queue(queue_name)
     queue.maybe_bind(conn)

--- a/kombu_sakura_simplemq/transport.py
+++ b/kombu_sakura_simplemq/transport.py
@@ -23,7 +23,7 @@ class Channel(virtual.Channel):
 
     @cached_property
     def zone(self):
-        return self.transport_options.get("zone") or "is1a"
+        return self.transport_options.get("zone") or "tk1b"
 
     @cached_property
     def api_host(self):
@@ -31,7 +31,7 @@ class Channel(virtual.Channel):
 
     @cached_property
     def api_key(self):
-        return self.transport_options.get("api_key")
+        return self.connection.client.password or self.transport_options.get("api_key")
 
     def _get_queue_url(self, queue):
         return "https://{}/v1/queues/{}".format(self.api_host, queue)


### PR DESCRIPTION
URLとして `sakura-simplemq://:APIKEY@` を利用可能とする。